### PR TITLE
Add simple todo list web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# forgpt
+# Todo List Web Application
+
+This repository contains a simple web-based Todo list application.
+
+## Usage
+Open `index.html` in your browser. You can add new tasks, which are stored locally in your browser's local storage.

--- a/README.md
+++ b/README.md
@@ -2,5 +2,14 @@
 
 This repository contains a simple web-based Todo list application.
 
-## Usage
-Open `index.html` in your browser. You can add new tasks, which are stored locally in your browser's local storage.
+## Running locally
+
+1. Start a lightweight web server from this directory:
+   
+   ```bash
+   python3 -m http.server 8000
+   ```
+
+2. Open `http://localhost:8000/index.html` in your browser.
+
+You can add and remove tasks, and they will be saved in your browser's local storage.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Todo List</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="app">
+        <h1>Todo List</h1>
+        <input type="text" id="new-todo" placeholder="Add a new task" />
+        <button id="add-btn">Add</button>
+        <ul id="todo-list"></ul>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,40 @@
+document.getElementById('add-btn').addEventListener('click', addTodo);
+
+document.addEventListener('DOMContentLoaded', loadTodos);
+
+function loadTodos() {
+    const todos = JSON.parse(localStorage.getItem('todos')) || [];
+    todos.forEach(addTodoItem);
+}
+
+function addTodo() {
+    const input = document.getElementById('new-todo');
+    const text = input.value.trim();
+    if (text === '') return;
+
+    const todos = JSON.parse(localStorage.getItem('todos')) || [];
+    todos.push(text);
+    localStorage.setItem('todos', JSON.stringify(todos));
+
+    addTodoItem(text);
+    input.value = '';
+}
+
+function addTodoItem(text) {
+    const list = document.getElementById('todo-list');
+    const li = document.createElement('li');
+    li.className = 'todo-item';
+    li.innerHTML = '<span>' + text + '</span> <button onclick="removeTodo(this)">x</button>';
+    list.appendChild(li);
+}
+
+function removeTodo(button) {
+    const li = button.parentElement;
+    const text = li.querySelector('span').textContent;
+
+    let todos = JSON.parse(localStorage.getItem('todos')) || [];
+    todos = todos.filter(t => t !== text);
+    localStorage.setItem('todos', JSON.stringify(todos));
+
+    li.remove();
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,34 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f5f5f5;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding-top: 50px;
+}
+
+#app {
+    background: white;
+    padding: 20px;
+    border-radius: 5px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    width: 300px;
+}
+
+#todo-list {
+    list-style: none;
+    padding: 0;
+}
+
+.todo-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 5px 0;
+}
+
+.todo-item button {
+    background: none;
+    border: none;
+    color: red;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add an HTML page with Todo list layout
- add styling and JS logic for adding/removing tasks using localStorage
- update README with usage instructions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68407fd49fe8832fb37bb8f513f9e772